### PR TITLE
Breaking URLs in references section of article

### DIFF
--- a/styles/bootstrap.less
+++ b/styles/bootstrap.less
@@ -216,3 +216,6 @@ footer[role="contentinfo"] {
 		border: none;
 	}
 }
+.item.references a {
+word-break: break-all;
+}


### PR DESCRIPTION
When a URL is too long it forces the small screen to miniaturize the viewing. This patch fixes it breaking by CSS these URLS. It has been tested as solution to this Community thread:
https://forum.pkp.sfu.ca/t/ojs-mobile-friendly/23655/12